### PR TITLE
Usando parâmetros default pra evitar checagem de conteúdo.

### DIFF
--- a/src/measures.py
+++ b/src/measures.py
@@ -43,20 +43,22 @@ class Measure(object):
         self.socket.setblocking(0)
         self.time = functools.partial(_TimeContext, self.socket, client, addresses)
 
-    def count(self, metric, counter=1, dimensions={}):
+    def count(self, metric, counter=1, dimensions=None):
         message = {
             'client': self.client,
             'metric': metric,
             'count': counter,
         }
+        dimensions = dimensions or {}
         dimensions.update(message)
         send_to(self.socket, self.addresses, dimensions)
 
-    def send(self, metric, dimensions={}):
+    def send(self, metric, dimensions=None):
         message = {
             'metric': metric,
             'client': self.client,
         }
+        dimensions = dimensions or {}
         dimensions.update(message)
         send_to(self.socket, self.addresses, dimensions)
 
@@ -68,3 +70,4 @@ def send_to(socket_obj, addresses, dimensions):
             socket_obj.sendto(buf, address)
     except socket.error as serr:
         logger.error('Error on sendto. [Errno {} - {}]'.format(serr.errno, serr.strerror))
+


### PR DESCRIPTION
* Usando parâmetros default pra evitar checagem de conteúdo.
* Retirado `exc_traceback` do `__exit__`, parametro não utilizado.